### PR TITLE
Fix missing mode and nickchange classes

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -701,7 +701,7 @@ function fixScrollMomentum(listview) {
 }
 
 /* Messagelist traffic messages */
-.messagelist-item-traffic {
+.messagelist-item-traffic, .messagelist-item-mode, .messagelist-item-nick {
     text-align: left;
     background-color: rgba(162, 165, 167, 0.6);
     padding-top: 10;


### PR DESCRIPTION
Mode and nick changes class was not defined in MessageList.vue, now nick and mode changes are aligned like traffic messages.